### PR TITLE
feat(xml-validation): add OpenAPI visitor

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
-= XSD Schema Policy
+= XML Validation Policy
 
 ifdef::env-github[]
-image:https://ci.gravitee.io/buildStatus/icon?job=gravitee-io/gravitee-policy-jsonschema/master["Build status", link="https://ci.gravitee.io/job/gravitee-io/job/gravitee-policy-jsonschema/"]
+image:https://ci.gravitee.io/buildStatus/icon?job=gravitee-io/gravitee-policy-xml-validation/master["Build status", link="https://ci.gravitee.io/job/gravitee-io/job/gravitee-policy-xml-validation/"]
 image:https://badges.gitter.im/Join Chat.svg["Gitter", link="https://gitter.im/gravitee-io/gravitee-io?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]
 endif::[]
 
@@ -19,8 +19,8 @@ endif::[]
 
 == Description
 
-The XSD Schema policy allows XML validation. This policy uses javax.xml.
-Return Error 400 BAD REQUEST when validation failed with with custom error message body.
+The XML Validation policy allows XML validation using XSD schema. This policy uses javax.xml.
+Return Error 400 BAD REQUEST when validation failed with custom error message body.
 Inject processing report messages into request metrics for analytics.
 
 
@@ -30,7 +30,7 @@ Inject processing report messages into request metrics for analytics.
 |Property |Required |Description |Type| Default
 
 .^|errorMessage
-^.^|X
+^.^|
 |Custom error message in XML format. Spel is allowed.
 ^.^|string
 |validation/internal
@@ -54,7 +54,7 @@ Inject processing report messages into request metrics for analytics.
 
 * Invalid payload
 
-* Invalid xsdschema
+* Invalid XSD schema
 
 * Invalid error message XML format
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,23 +21,28 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.gravitee.policy</groupId>
-    <artifactId>gravitee-policy-xsd</artifactId>
+    <artifactId>gravitee-policy-xml-validation</artifactId>
     <version>1.0.0-SNAPSHOT</version>
 
-    <name>Gravitee.io APIM - Policy - Jsonschema</name>
-    <description>Description of the XSD validation - XSD Gravitee Policy</description>
+    <name>Gravitee.io APIM - Policy - XML Validation</name>
+    <description>Description of the XML validation Policy</description>
 
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>10</version>
+        <version>19</version>
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.9.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.2.0</gravitee-policy-api.version>
+        <gravitee-gateway-api.version>1.20.0</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.8.0</gravitee-policy-api.version>
+        <gravitee-gateway-buffer.version>3.0.0</gravitee-gateway-buffer.version>
+
+        <swagger-parser.version>2.0.22</swagger-parser.version>
+        <mockito.version>3.5.13</mockito.version>
+        <json2xsd.version>2.2.0</json2xsd.version>
+
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
-        <gravitee-gateway.version>1.16.0</gravitee-gateway.version>
     </properties>
 
     <dependencies>
@@ -48,6 +53,7 @@
             <version>${gravitee-gateway-api.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
@@ -62,6 +68,25 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Swagger -->
+        <dependency>
+            <groupId>io.swagger.parser.v3</groupId>
+            <artifactId>swagger-parser</artifactId>
+            <version>${swagger-parser.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ethlo.jsons2xsd</groupId>
+            <artifactId>jsons2xsd</artifactId>
+            <version>${json2xsd.version}</version>
+        </dependency>
+
         <!-- Test scope -->
         <dependency>
             <groupId>junit</groupId>
@@ -69,10 +94,15 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
@@ -85,25 +115,12 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-buffer</artifactId>
-            <version>${gravitee-gateway.version}</version>
+            <version>${gravitee-gateway-buffer.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.8.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.el</groupId>
-            <artifactId>gravitee-expression-language</artifactId>
-            <version>1.0.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.gateway</groupId>
-            <artifactId>gravitee-gateway-el</artifactId>
-            <version>${gravitee-gateway.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/policy/xmlvalidation/configuration/XmlValidationPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/xmlvalidation/configuration/XmlValidationPolicyConfiguration.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.xmlvalidation.configuration;
+
+import io.gravitee.policy.api.PolicyConfiguration;
+
+public class XmlValidationPolicyConfiguration implements PolicyConfiguration {
+
+    private String errorMessage;
+
+    private String xsdSchema;
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getXsdSchema() {
+        return xsdSchema;
+    }
+
+    public void setXsdSchema(String xsdSchema) {
+        this.xsdSchema = xsdSchema;
+    }
+}

--- a/src/main/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationOAIOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationOAIOperationVisitor.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.xmlvalidation.swagger;
+
+import com.ethlo.jsons2xsd.Config;
+import com.ethlo.jsons2xsd.JsonSimpleType;
+import com.ethlo.jsons2xsd.Jsons2Xsd;
+import com.ethlo.jsons2xsd.XsdSimpleType;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.gravitee.policy.api.swagger.Policy;
+import io.gravitee.policy.api.swagger.v3.OAIOperationVisitor;
+import io.gravitee.policy.xmlvalidation.configuration.XmlValidationPolicyConfiguration;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import org.apache.commons.lang3.StringUtils;
+import org.w3c.dom.DOMConfiguration;
+import org.w3c.dom.Document;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSSerializer;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Optional;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class XmlValidationOAIOperationVisitor implements OAIOperationVisitor {
+
+    public static final String XSD_TARGET_NAMESPACE = "urn:io:gravitee:policy:xml-validation";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    {
+        mapper.configure(JsonGenerator.Feature.WRITE_NUMBERS_AS_STRINGS, true);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    @Override
+    /**
+     * openAPI has been parsed with the "resolveFully" option. As a consequence, all $ref have been replaced by proper definition.
+     */
+    public Optional<Policy> visit(io.swagger.v3.oas.models.OpenAPI openAPI, io.swagger.v3.oas.models.Operation operation) {
+        String jsonSchema = null;
+        final RequestBody requestBody = operation.getRequestBody();
+        if (requestBody != null && requestBody.getContent() != null && requestBody.getContent().get("application/xml") != null) {
+            final Schema schema = requestBody.getContent().get("application/xml").getSchema();
+            jsonSchema = Json.pretty(schema);
+        }
+        if (!StringUtils.isEmpty(jsonSchema)) {
+            XmlValidationPolicyConfiguration configuration = new XmlValidationPolicyConfiguration();
+            try {
+                String xmlSchema = convert(jsonSchema);
+
+                Policy policy = new Policy();
+                policy.setName("xml-validation");
+                configuration.setXsdSchema(xmlSchema);
+                policy.setConfiguration(mapper.writeValueAsString(configuration));
+                return Optional.of(policy);
+            } catch (IOException | IllegalAccessException | InstantiationException | ClassNotFoundException e) {
+                e.printStackTrace();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private String convert(String jsonSchema) throws IOException, InstantiationException, IllegalAccessException, ClassNotFoundException {
+        try(Reader jsonReader = new StringReader(jsonSchema)) {
+            final Config cfg = new Config.Builder()
+                    .name("rootType")
+                    .targetNamespace(XSD_TARGET_NAMESPACE)
+                    .createRootElement(true)
+                    .nsAlias("ns")
+                    .rootElement("root")
+                    .validateXsdSchema(true)
+                    .customTypeMapping(JsonSimpleType.INTEGER, "int64", XsdSimpleType.LONG)
+                    .build();
+            final Document xmlSchemaDoc = Jsons2Xsd.convert(jsonReader, cfg);
+
+            DOMImplementationLS impl = (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS");
+
+            LSSerializer writer = impl.createLSSerializer();
+            DOMConfiguration config = writer.getDomConfig();
+            config.setParameter("format-pretty-print", Boolean.TRUE);
+
+            return writer.writeToString(xmlSchemaDoc);
+        }
+    }
+}

--- a/src/main/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationSwaggerOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationSwaggerOperationVisitor.java
@@ -13,29 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.policy.http.xsd.configuration;
+package io.gravitee.policy.xmlvalidation.swagger;
 
-import io.gravitee.policy.api.PolicyConfiguration;
+import io.gravitee.policy.api.swagger.Policy;
+import io.gravitee.policy.api.swagger.v2.SwaggerOperationVisitor;
+import io.swagger.models.Operation;
+import io.swagger.models.Swagger;
 
-public class XsdValidatorPolicyConfiguration implements PolicyConfiguration {
+import java.util.Optional;
 
-    private String errorMessage;
-
-    private String xsdSchema;
-
-    public String getErrorMessage() {
-        return errorMessage;
-    }
-
-    public void setErrorMessage(String errorMessage) {
-        this.errorMessage = errorMessage;
-    }
-
-    public String getXsdSchema() {
-        return xsdSchema;
-    }
-
-    public void setXsdSchema(String xsdSchema) {
-        this.xsdSchema = xsdSchema;
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class XmlValidationSwaggerOperationVisitor implements SwaggerOperationVisitor {
+    @Override
+    public Optional<Policy> visit(Swagger swagger, Operation o) {
+        return Optional.empty();
     }
 }

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -1,6 +1,6 @@
-id=policy-xsdschema-validator
-name=Xsd Schema validator
+id=xml-validation
+name=XML Validation
 version=${project.version}
 description=${project.description}
-class=io.gravitee.policy.http.xsd.XsdValidatorPolicy
+class=io.gravitee.policy.xmlvalidation.XmlValidationPolicy
 type=policy

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,6 +1,6 @@
 {
   "type" : "object",
-  "id" : "urn:xsdschema:io:gravitee:policy:http:xsd:configuration:XsdValidatorPolicyConfiguration",
+  "id" : "urn:xmlschema:io:gravitee:policy:XmlValidationPolicyConfiguration",
   "properties" : {
     "errorMessage": {
       "title": "Http error message",
@@ -21,12 +21,12 @@
     },
     "xsdSchema": {
       "title": "xsdSchema",
-      "description": "XsdSchema used for request payload validation",
+      "description": "XML schema used for request payload validation",
       "type": "string",
       "x-schema-form": {
         "type": "codemirror",
         "codemirrorOptions": {
-          "placeholder": "Put your xsd schema here or drag'n'drop it",
+          "placeholder": "Put your xml schema here or drag'n'drop it",
           "lineWrapping": true,
           "lineNumbers": true,
           "allowDropFileTypes": true,
@@ -34,10 +34,9 @@
           "mode": "xml"
         }
       }
-    },
-    "required": [
-      "xsdSchema",
-      "errorMessage"
-    ]
-  }
+    }
+  },
+  "required": [
+    "xsdSchema"
+  ]
 }

--- a/src/test/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationOAIOperationVisitorTest.java
+++ b/src/test/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationOAIOperationVisitorTest.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.xmlvalidation.swagger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.policy.api.swagger.Policy;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class XmlValidationOAIOperationVisitorTest {
+
+    private XmlValidationOAIOperationVisitor visitor = new XmlValidationOAIOperationVisitor();
+
+    @Test
+    public void operationWithoutRequestBody() {
+        Operation operationMock = mock(Operation.class);
+
+        when(operationMock.getRequestBody()).thenReturn(null);
+        Optional<Policy> policy = visitor.visit(mock(OpenAPI.class), operationMock);
+        assertFalse(policy.isPresent());
+    }
+
+    @Test
+    public void operationWithoutApplicationJsonRequestBody() {
+        Operation operationMock = mock(Operation.class);
+
+        Content content = mock(Content.class);
+        RequestBody requestBody = mock(RequestBody.class);
+        when(operationMock.getRequestBody()).thenReturn(requestBody);
+        when(requestBody.getContent()).thenReturn(content);
+        when(content.get("application/xml")).thenReturn(null);
+
+        Optional<Policy> policy = visitor.visit(mock(OpenAPI.class), operationMock);
+        assertFalse(policy.isPresent());
+    }
+
+    @Test
+    public void operationWithEmptyRequestBody() {
+        Operation operationMock = mock(Operation.class);
+
+        MediaType applicationXml = mock(MediaType.class);
+        Content content = mock(Content.class);
+        RequestBody requestBody = mock(RequestBody.class);
+        when(operationMock.getRequestBody()).thenReturn(requestBody);
+        when(requestBody.getContent()).thenReturn(content);
+        when(content.get("application/xml")).thenReturn(applicationXml);
+
+        try(MockedStatic<Json> theMock = Mockito.mockStatic(Json.class)) {
+            theMock.when(() -> Json.pretty(any(Schema.class))).thenReturn("");
+            Optional<Policy> policy = visitor.visit(mock(OpenAPI.class), operationMock);
+            assertFalse(policy.isPresent());
+        }
+    }
+
+    @Test
+    public void operationWithJsonRequestBody() throws Exception {
+        final String jsonSchema = "{\n" +
+                "  \"title\": \"Person\",\n" +
+                "  \"type\": \"object\",\n" +
+                "  \"properties\": {\n" +
+                "    \"firstName\": {\n" +
+                "      \"type\": \"string\",\n" +
+                "      \"description\": \"The person's first name.\"\n" +
+                "    },\n" +
+                "    \"lastName\": {\n" +
+                "      \"type\": \"string\",\n" +
+                "      \"description\": \"The person's last name.\"\n" +
+                "    },\n" +
+                "    \"age\": {\n" +
+                "      \"description\": \"Age in years which must be equal to or greater than zero.\",\n" +
+                "      \"type\": \"integer\",\n" +
+                "      \"format\": \"int64\",\n" +
+                "      \"minimum\": 0\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        final String expectedXsdSchema = "<?xml version=\"1.0\" encoding=\"UTF-16\"?><schema xmlns=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" targetNamespace=\"" + XmlValidationOAIOperationVisitor.XSD_TARGET_NAMESPACE + "\" xmlns:ns=\"" + XmlValidationOAIOperationVisitor.XSD_TARGET_NAMESPACE + "\">\n" +
+                "    <element name=\"root\" type=\"ns:rootType\"/>\n" +
+                "    <complexType name=\"rootType\">\n" +
+                "        <sequence>\n" +
+                "            <element minOccurs=\"0\" name=\"firstName\" type=\"string\">\n" +
+                "                <annotation>\n" +
+                "                    <documentation>The person's first name.</documentation>\n" +
+                "                </annotation>\n" +
+                "            </element>\n" +
+                "            <element minOccurs=\"0\" name=\"lastName\" type=\"string\">\n" +
+                "                <annotation>\n" +
+                "                    <documentation>The person's last name.</documentation>\n" +
+                "                </annotation>\n" +
+                "            </element>\n" +
+                "            <element minOccurs=\"0\" name=\"age\" type=\"long\">\n" +
+                "                <annotation>\n" +
+                "                    <documentation>Age in years which must be equal to or greater than zero.</documentation>\n" +
+                "                </annotation>\n" +
+                "            </element>\n" +
+                "        </sequence>\n" +
+                "    </complexType>\n" +
+                "</schema>\n";
+
+        Operation operationMock = mock(Operation.class);
+
+        Schema schema = mock(Schema.class);
+        MediaType applicationXml = mock(MediaType.class);
+        Content content = mock(Content.class);
+        RequestBody requestBody = mock(RequestBody.class);
+        when(operationMock.getRequestBody()).thenReturn(requestBody);
+        when(requestBody.getContent()).thenReturn(content);
+        when(content.get("application/xml")).thenReturn(applicationXml);
+        when(applicationXml.getSchema()).thenReturn(schema);
+
+        try(MockedStatic<Json> theMock = Mockito.mockStatic(Json.class)) {
+            theMock.when(() -> Json.pretty(any(Schema.class))).thenReturn(jsonSchema);
+
+            Optional<Policy> policy = visitor.visit(mock(OpenAPI.class), operationMock);
+            assertTrue(policy.isPresent());
+
+            String configuration = policy.get().getConfiguration();
+            assertNotNull(configuration);
+            HashMap readConfig = new ObjectMapper().readValue(configuration, HashMap.class);
+            assertEquals(expectedXsdSchema, readConfig.get("xsdSchema"));
+        }
+    }
+}


### PR DESCRIPTION
Initialize a xml-validation config for each API operation with an XML request body.
Rename to "XML-validation"

Closes gravitee-io/issues#4294