### PR TITLE
fix(build): remove whitespace before comparison

### DIFF
--- a/src/test/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationOAIOperationVisitorTest.java
+++ b/src/test/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationOAIOperationVisitorTest.java
@@ -154,7 +154,7 @@ public class XmlValidationOAIOperationVisitorTest {
             String configuration = policy.get().getConfiguration();
             assertNotNull(configuration);
             HashMap readConfig = new ObjectMapper().readValue(configuration, HashMap.class);
-            assertEquals(expectedXsdSchema, readConfig.get("xsdSchema"));
+            assertEquals(expectedXsdSchema.replaceAll("\\s", ""), ((String) readConfig.get("xsdSchema")).replaceAll("\\s", ""));
         }
     }
 }


### PR DESCRIPTION
Allow both JDK 8 and 11 to successfully run the test