### PR TITLE
fix(documentation): fixed typos in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ endif::[]
 == Description
 
 You can use the `xml-validation` policy to validate XML using an XSD schema. This policy uses `javax.xml`.
-A 400 BAD REQUEST error is received with a custom error message body wwith a custom error message body hen validation fails.
+A 400 BAD REQUEST error is received with a custom error message body with a custom error message body when validation fails.
 Injects processing report messages into request metrics for analytics.
 
 


### PR DESCRIPTION
Fixes 2 little typos in the README.adoc
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-xml-validation/1.2.0/gravitee-policy-xml-validation-1.2.0.zip)
  <!-- Version placeholder end -->
