### PR TITLE
fix: check if the schema properties property is not null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-gateway-buffer.version>3.0.13</gravitee-gateway-buffer.version>
 
         <swagger-parser.version>2.0.22</swagger-parser.version>
-        <mockito.version>3.5.13</mockito.version>
+        <mockito.version>5.13.0</mockito.version>
         <json2xsd.version>2.2.0</json2xsd.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
+            <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
         <!--

--- a/src/main/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationOAIOperationVisitor.java
+++ b/src/main/java/io/gravitee/policy/xmlvalidation/swagger/XmlValidationOAIOperationVisitor.java
@@ -63,11 +63,12 @@ public class XmlValidationOAIOperationVisitor implements OAIOperationVisitor {
     public Optional<Policy> visit(io.swagger.v3.oas.models.OpenAPI openAPI, io.swagger.v3.oas.models.Operation operation) {
         String jsonSchema = null;
         final RequestBody requestBody = operation.getRequestBody();
+        Schema schema = new Schema<>();
         if (requestBody != null && requestBody.getContent() != null && requestBody.getContent().get("application/xml") != null) {
-            final Schema schema = requestBody.getContent().get("application/xml").getSchema();
+            schema = requestBody.getContent().get("application/xml").getSchema();
             jsonSchema = Json.pretty(schema);
         }
-        if (!StringUtils.isEmpty(jsonSchema)) {
+        if (!StringUtils.isEmpty(jsonSchema) && schema.getProperties() != null) {
             XmlValidationPolicyConfiguration configuration = new XmlValidationPolicyConfiguration();
             try {
                 String xmlSchema = convert(jsonSchema);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6043

**Description**

Check if the schema properties property is not null in the policy object

**Additional context**
![Screenshot 2025-01-07 at 13-13-00 Gravitee io Management](https://github.com/user-attachments/assets/21e54207-3926-4f37-9270-6851440ef21c)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
